### PR TITLE
Ensure the docs list if emptied between repeated uses.

### DIFF
--- a/havenondemand/hodindex.py
+++ b/havenondemand/hodindex.py
@@ -150,12 +150,12 @@ class HODAsyncResponse(HODResponse):
 
 class Index:
 
-	docs=[];
 	client= None
 	name=""
 	def __init__(self,client,name):
 		self.client=client
 		self.name=name
+		self.docs=[]
 
 	def size(self):
 		return len(self.docs)


### PR DESCRIPTION
This change prevents the list of docs being indexed from growing indefintely.  Ultimately the list grows so large that you get timeouts and errors.

